### PR TITLE
Fix spacing after comma for init_message

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -26,7 +26,7 @@
     <string name="release_note_close_remind">Don\'t ask again</string>
 
     <!--init-->
-    <string name="init_message">Data is updating now ,please don\'t close MyDairy</string>
+    <string name="init_message">Data is updating now, please don\'t close MyDairy</string>
 
     <!--Profile-->
     <string name="profile_username_taki">Taki</string>


### PR DESCRIPTION
I noticed this issue when I start the app so I just did a quick fix here.
Sorry for being punctuation nazi :P
If you think that this fix is unnecessary feel free to close this PR.